### PR TITLE
Add multi-page Svelte UI with dedicated tutorial sections

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,388 +1,259 @@
 <script>
   import { onMount } from "svelte";
-  import {
-    registerUser,
-    loginUser,
-    getItems,
-    getProfile,
-    createItem,
-    updateItem,
-    deleteItem
-  } from "./lib/api";
-  import { token, currentUser } from "./stores/auth";
   import { get } from "svelte/store";
+  import AuthPage from "./pages/AuthPage.svelte";
+  import CrudPage from "./pages/CrudPage.svelte";
+  import DatabaseQueryPage from "./pages/DatabaseQueryPage.svelte";
+  import CoreFeaturesPage from "./pages/CoreFeaturesPage.svelte";
+  import { getProfile } from "./lib/api";
+  import { token, currentUser } from "./stores/auth";
 
-  let registerForm = { email: "", password: "" };
-  let loginForm = { email: "", password: "" };
-  let itemForm = { id: null, title: "", description: "" };
-  let items = [];
-  let total = 0;
-  let loading = false;
-  let errorMessage = "";
-  let successMessage = "";
-
-  async function handleRegister(event) {
-    event.preventDefault();
-    loading = true;
-    errorMessage = "";
-    successMessage = "";
-    try {
-      await registerUser(registerForm);
-      successMessage = "Registration successful! Please sign in.";
-      registerForm = { email: "", password: "" };
-    } catch (error) {
-      errorMessage = error.response?.data?.detail ?? "Registration failed";
-    } finally {
-      loading = false;
+  const pages = [
+    {
+      id: "auth",
+      title: "Authentication",
+      description: "Create an account or sign in to obtain a bearer token from FastAPI.",
+      component: AuthPage,
+      requiresAuth: false
+    },
+    {
+      id: "crud",
+      title: "CRUD dashboard",
+      description: "Manage notes that are stored in SQLite via FastAPI endpoints.",
+      component: CrudPage,
+      requiresAuth: true
+    },
+    {
+      id: "database",
+      title: "Database queries",
+      description: "Explore pagination and derived metrics using the items API.",
+      component: DatabaseQueryPage,
+      requiresAuth: true
+    },
+    {
+      id: "core",
+      title: "Core Svelte features",
+      description: "Play with reactivity, bindings, and stores in an isolated playground.",
+      component: CoreFeaturesPage,
+      requiresAuth: false
     }
-  }
+  ];
 
-  async function handleLogin(event) {
-    event.preventDefault();
-    loading = true;
-    errorMessage = "";
-    successMessage = "";
-    try {
-      const { access_token } = await loginUser(loginForm);
-      token.set(access_token);
-      await loadProfile();
-      await loadItems();
-      loginForm = { email: "", password: "" };
-    } catch (error) {
-      errorMessage = error.response?.data?.detail ?? "Login failed";
-    } finally {
-      loading = false;
-    }
-  }
+  const pageMap = new Map(pages.map((page) => [page.id, page]));
+
+  let activePage = pages[0].id;
+  let profileError = "";
+  let loadingProfile = false;
 
   async function loadProfile() {
+    if (!get(token)) {
+      currentUser.set(null);
+      return;
+    }
+    loadingProfile = true;
+    profileError = "";
     try {
       const profile = await getProfile();
       currentUser.set(profile);
     } catch (error) {
+      profileError = error.response?.data?.detail ?? "Could not load profile";
       token.set(null);
       currentUser.set(null);
-    }
-  }
-
-  async function loadItems() {
-    if (!get(token)) {
-      items = [];
-      total = 0;
-      return;
-    }
-    loading = true;
-    try {
-      const response = await getItems();
-      items = response.items;
-      total = response.total;
-    } catch (error) {
-      errorMessage = error.response?.data?.detail ?? "Could not load items";
     } finally {
-      loading = false;
+      loadingProfile = false;
     }
-  }
-
-  async function handleItemSubmit(event) {
-    event.preventDefault();
-    loading = true;
-    errorMessage = "";
-    successMessage = "";
-    try {
-      if (itemForm.id) {
-        await updateItem(itemForm.id, {
-          title: itemForm.title,
-          description: itemForm.description
-        });
-        successMessage = "Item updated";
-      } else {
-        await createItem({
-          title: itemForm.title,
-          description: itemForm.description
-        });
-        successMessage = "Item created";
-      }
-      itemForm = { id: null, title: "", description: "" };
-      await loadItems();
-    } catch (error) {
-      errorMessage = error.response?.data?.detail ?? "Could not save item";
-    } finally {
-      loading = false;
-    }
-  }
-
-  function startEdit(item) {
-    itemForm = { id: item.id, title: item.title, description: item.description ?? "" };
-  }
-
-  async function handleDelete(id) {
-    loading = true;
-    try {
-      await deleteItem(id);
-      await loadItems();
-    } catch (error) {
-      errorMessage = error.response?.data?.detail ?? "Could not delete item";
-    } finally {
-      loading = false;
-    }
-  }
-
-  function handleLogout() {
-    token.set(null);
-    currentUser.set(null);
-    items = [];
-    total = 0;
   }
 
   onMount(async () => {
     if (get(token)) {
       await loadProfile();
-      await loadItems();
+      activePage = "crud";
     }
   });
+
+  function handleLogout() {
+    token.set(null);
+    currentUser.set(null);
+    activePage = "auth";
+  }
+
+  async function handleLoginSuccess() {
+    await loadProfile();
+    activePage = "crud";
+  }
+
+  $: activeDefinition = pageMap.get(activePage) ?? pages[0];
+  $: if (!$token && activeDefinition.requiresAuth) {
+    activePage = "auth";
+  }
 </script>
 
-<main class="layout">
-  <section class="hero">
-    <h1>FastAPI + Svelte productivity board</h1>
-    <p>
-      This demo showcases authentication, database-backed CRUD operations, and reactive UI powered by
-      FastAPI and Svelte.
-    </p>
-  </section>
-
-  {#if errorMessage}
-    <div class="alert error">{errorMessage}</div>
-  {/if}
-  {#if successMessage}
-    <div class="alert success">{successMessage}</div>
-  {/if}
-
-  <section class="auth-grid">
-    <div class="card">
-      <h2>Register</h2>
-      <form on:submit|preventDefault={handleRegister}>
-        <label>
-          Email
-          <input type="email" bind:value={registerForm.email} required />
-        </label>
-        <label>
-          Password
-          <input type="password" bind:value={registerForm.password} minlength="6" required />
-        </label>
-        <button type="submit" disabled={loading}>Create account</button>
-      </form>
+<div class="app-shell">
+  <header class="app-header">
+    <div class="brand">
+      <span class="brand-accent">FastAPI</span>
+      <span>+</span>
+      <span class="brand-accent">Svelte</span>
+      <span>tutorial</span>
     </div>
 
-    <div class="card">
-      <h2>Sign in</h2>
-      <form on:submit|preventDefault={handleLogin}>
-        <label>
-          Email
-          <input type="email" bind:value={loginForm.email} required />
-        </label>
-        <label>
-          Password
-          <input type="password" bind:value={loginForm.password} required />
-        </label>
-        <button type="submit" disabled={loading}>Sign in</button>
-      </form>
-    </div>
-  </section>
+    <nav class="main-nav">
+      {#each pages as page}
+        <button
+          type="button"
+          class:active={page.id === activePage}
+          disabled={page.requiresAuth && !$token}
+          on:click={() => (activePage = page.id)}
+        >
+          {page.title}
+        </button>
+      {/each}
+    </nav>
 
-  {#if $currentUser}
-    <section class="card user-card">
-      <div class="user-details">
-        <h2>Welcome back, {$currentUser.email}</h2>
-        <p>You're authenticated. Create, update or delete notes that are persisted in SQLite.</p>
+    {#if $currentUser}
+      <div class="user-chip">
+        <span>{$currentUser.email}</span>
+        <button type="button" class="logout" on:click={handleLogout}>Log out</button>
       </div>
-      <button class="logout" on:click={handleLogout}>Log out</button>
+    {/if}
+  </header>
+
+  <main class="content">
+    <section class="intro">
+      <h1>{activeDefinition.title}</h1>
+      <p>{activeDefinition.description}</p>
     </section>
 
-    <section class="card">
-      <h2>{itemForm.id ? "Update" : "Create"} item</h2>
-      <form on:submit|preventDefault={handleItemSubmit}>
-        <label>
-          Title
-          <input type="text" bind:value={itemForm.title} required />
-        </label>
-        <label>
-          Description
-          <textarea rows="3" bind:value={itemForm.description} placeholder="What are you working on?"></textarea>
-        </label>
-        <div class="actions">
-          <button type="submit" disabled={loading}>
-            {itemForm.id ? "Save changes" : "Add item"}
-          </button>
-          {#if itemForm.id}
-            <button type="button" class="secondary" on:click={() => (itemForm = { id: null, title: "", description: "" })}>
-              Cancel
-            </button>
-          {/if}
-        </div>
-      </form>
-    </section>
+    {#if profileError}
+      <div class="alert error">{profileError}</div>
+    {/if}
+    {#if loadingProfile}
+      <div class="alert info">Loading profile…</div>
+    {/if}
 
-    <section class="card">
-      <div class="items-header">
-        <h2>Your items ({total})</h2>
-        <button class="secondary" on:click={loadItems} disabled={loading}>Refresh</button>
-      </div>
-      {#if items.length === 0}
-        <p class="empty">No items yet. Create your first one!</p>
-      {:else}
-        <ul class="items">
-          {#each items as item}
-            <li>
-              <div>
-                <h3>{item.title}</h3>
-                {#if item.description}
-                  <p>{item.description}</p>
-                {/if}
-              </div>
-              <div class="item-actions">
-                <button class="secondary" on:click={() => startEdit(item)}>Edit</button>
-                <button class="danger" on:click={() => handleDelete(item.id)}>Delete</button>
-              </div>
-            </li>
-          {/each}
-        </ul>
-      {/if}
+    <section class="page-container">
+      <svelte:component
+        this={activeDefinition.component}
+        on:loginSuccess={handleLoginSuccess}
+        on:requestProfileRefresh={loadProfile}
+      />
     </section>
-  {/if}
-</main>
+  </main>
+</div>
 
 <style>
-  .layout {
-    max-width: 960px;
-    margin: 0 auto;
-    padding: 2rem 1.5rem 4rem;
+  .app-shell {
+    min-height: 100vh;
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
   }
 
-  .hero {
-    background: white;
-    padding: 2rem;
-    border-radius: 1rem;
-    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
-  }
-
-  .hero h1 {
-    margin-top: 0;
-    margin-bottom: 0.75rem;
-  }
-
-  .auth-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 1.5rem;
-  }
-
-  .card {
-    background: white;
-    padding: 1.5rem;
-    border-radius: 1rem;
-    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
-  }
-
-  form {
+  .app-header {
     display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .actions {
-    display: flex;
-    gap: 0.75rem;
     flex-wrap: wrap;
     align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.5rem clamp(1rem, 5vw, 3rem);
   }
 
-  label {
+  .brand {
     display: flex;
-    flex-direction: column;
+    align-items: center;
     gap: 0.35rem;
-    font-weight: 600;
+    font-weight: 700;
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
   }
 
-  input,
-  textarea {
-    border: 1px solid #cbd5e0;
-    border-radius: 0.75rem;
-    padding: 0.65rem 0.85rem;
-    font-size: 0.95rem;
-    transition: border-color 0.2s ease;
+  .brand-accent {
+    color: #4c51bf;
   }
 
-  input:focus,
-  textarea:focus {
-    outline: none;
-    border-color: #4299e1;
-    box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.3);
+  .main-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
   }
 
-  button {
+  .main-nav button {
     border: none;
     border-radius: 999px;
-    padding: 0.6rem 1.4rem;
+    padding: 0.45rem 1.1rem;
+    background: rgba(66, 153, 225, 0.12);
+    color: #2b2d42;
     font-weight: 600;
-    background: linear-gradient(135deg, #4299e1, #667eea);
-    color: white;
-    transition: filter 0.2s ease;
+    transition: all 0.2s ease;
   }
 
-  button:disabled {
-    opacity: 0.6;
+  .main-nav button.active {
+    background: linear-gradient(135deg, #4299e1, #667eea);
+    color: white;
+    box-shadow: 0 10px 20px rgba(76, 81, 191, 0.2);
+  }
+
+  .main-nav button:disabled {
+    opacity: 0.4;
     cursor: not-allowed;
   }
 
-  button:not(:disabled):hover {
-    filter: brightness(1.05);
+  .user-chip {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: white;
+    padding: 0.65rem 1rem;
+    border-radius: 999px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
   }
 
-  .secondary {
-    background: #edf2f7;
-    color: #2d3748;
+  .user-chip span {
+    font-weight: 600;
   }
 
-  .danger {
+  .logout {
     background: #f56565;
+    color: white;
+    border: none;
+    border-radius: 999px;
+    padding: 0.35rem 0.9rem;
+    font-weight: 600;
   }
 
-  .items {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+  .content {
+    flex: 1;
+    max-width: 1100px;
+    width: min(100%, 1100px);
+    margin: 0 auto;
+    padding: 0 1.5rem 3rem;
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 1.5rem;
   }
 
-  .items li {
-    display: flex;
-    justify-content: space-between;
-    gap: 1rem;
-    border: 1px solid #e2e8f0;
-    border-radius: 1rem;
-    padding: 1rem;
+  .intro {
+    background: white;
+    padding: clamp(1.5rem, 3vw, 2.5rem);
+    border-radius: 1.25rem;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
   }
 
-  .items li h3 {
-    margin: 0 0 0.35rem;
+  .intro h1 {
+    margin: 0 0 0.5rem;
+    font-size: clamp(1.5rem, 3vw, 2rem);
   }
 
-  .item-actions {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
+  .intro p {
+    margin: 0;
+    color: #4a5568;
   }
 
   .alert {
     padding: 0.75rem 1rem;
-    border-radius: 0.75rem;
+    border-radius: 0.85rem;
     font-weight: 600;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
   }
 
   .alert.error {
@@ -390,42 +261,24 @@
     color: #742a2a;
   }
 
-  .alert.success {
-    background: #c6f6d5;
-    color: #22543d;
+  .alert.info {
+    background: #ebf8ff;
+    color: #1a365d;
   }
 
-  .user-card {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1rem;
-  }
-
-  .logout {
-    background: #f56565;
-  }
-
-  .items-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1rem;
-  }
-
-  .empty {
-    color: #718096;
-    margin: 0;
+  .page-container {
+    background: transparent;
+    display: grid;
   }
 
   @media (max-width: 640px) {
-    .items li {
-      flex-direction: column;
-      align-items: stretch;
+    .app-header {
+      justify-content: center;
     }
 
-    .item-actions {
-      justify-content: flex-end;
+    .user-chip {
+      width: 100%;
+      justify-content: space-between;
     }
   }
 </style>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -37,8 +37,8 @@ export async function getProfile() {
   return response.data;
 }
 
-export async function getItems() {
-  const response = await client.get("/items");
+export async function getItems(params = {}) {
+  const response = await client.get("/items", { params });
   return response.data;
 }
 

--- a/frontend/src/pages/AuthPage.svelte
+++ b/frontend/src/pages/AuthPage.svelte
@@ -1,0 +1,187 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+  import { registerUser, loginUser, getProfile } from "../lib/api";
+  import { token, currentUser } from "../stores/auth";
+
+  const dispatch = createEventDispatcher();
+
+  let registerForm = { email: "", password: "" };
+  let loginForm = { email: "", password: "" };
+  let loading = false;
+  let errorMessage = "";
+  let successMessage = "";
+
+  function resetFeedback() {
+    errorMessage = "";
+    successMessage = "";
+  }
+
+  async function handleRegister(event) {
+    event.preventDefault();
+    resetFeedback();
+    loading = true;
+    try {
+      await registerUser(registerForm);
+      successMessage = "Registration successful! You can sign in right away.";
+      registerForm = { email: "", password: "" };
+      dispatch("registrationSuccess");
+    } catch (error) {
+      errorMessage = error.response?.data?.detail ?? "Registration failed";
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleLogin(event) {
+    event.preventDefault();
+    resetFeedback();
+    loading = true;
+    try {
+      const { access_token } = await loginUser(loginForm);
+      token.set(access_token);
+      const profile = await getProfile();
+      currentUser.set(profile);
+      successMessage = `Welcome back, ${profile.email}!`;
+      loginForm = { email: "", password: "" };
+      dispatch("loginSuccess");
+    } catch (error) {
+      errorMessage = error.response?.data?.detail ?? "Login failed";
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+
+<div class="auth-grid">
+  <section class="panel">
+    <header>
+      <h2>Register</h2>
+      <p>Create a new account backed by the FastAPI users table.</p>
+    </header>
+    <form on:submit={handleRegister}>
+      <label>
+        Email
+        <input type="email" bind:value={registerForm.email} required />
+      </label>
+      <label>
+        Password
+        <input type="password" bind:value={registerForm.password} minlength="6" required />
+      </label>
+      <button type="submit" disabled={loading}>Create account</button>
+    </form>
+  </section>
+
+  <section class="panel">
+    <header>
+      <h2>Sign in</h2>
+      <p>Receive a bearer token and persist it in local storage.</p>
+    </header>
+    <form on:submit={handleLogin}>
+      <label>
+        Email
+        <input type="email" bind:value={loginForm.email} required />
+      </label>
+      <label>
+        Password
+        <input type="password" bind:value={loginForm.password} required />
+      </label>
+      <button type="submit" disabled={loading}>Sign in</button>
+    </form>
+  </section>
+</div>
+
+{#if errorMessage}
+  <div class="feedback error">{errorMessage}</div>
+{/if}
+{#if successMessage}
+  <div class="feedback success">{successMessage}</div>
+{/if}
+
+<style>
+  .auth-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .panel {
+    background: white;
+    padding: 1.75rem;
+    border-radius: 1.25rem;
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 1.25rem;
+  }
+
+  header h2 {
+    margin: 0 0 0.35rem;
+  }
+
+  header p {
+    margin: 0;
+    color: #4a5568;
+    font-size: 0.95rem;
+  }
+
+  form {
+    display: grid;
+    gap: 1rem;
+  }
+
+  label {
+    display: grid;
+    gap: 0.4rem;
+    font-weight: 600;
+  }
+
+  input {
+    border: 1px solid #cbd5e0;
+    border-radius: 0.85rem;
+    padding: 0.7rem 0.85rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    font-size: 1rem;
+  }
+
+  input:focus {
+    outline: none;
+    border-color: #4299e1;
+    box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.25);
+  }
+
+  button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.75rem 1.5rem;
+    font-weight: 600;
+    background: linear-gradient(135deg, #4299e1, #667eea);
+    color: white;
+    transition: filter 0.2s ease;
+  }
+
+  button:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
+  }
+
+  button:not(:disabled):hover {
+    filter: brightness(1.05);
+  }
+
+  .feedback {
+    margin-top: 1.5rem;
+    padding: 0.85rem 1rem;
+    border-radius: 0.9rem;
+    font-weight: 600;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  }
+
+  .feedback.error {
+    background: #fed7d7;
+    color: #742a2a;
+  }
+
+  .feedback.success {
+    background: #c6f6d5;
+    color: #22543d;
+  }
+</style>

--- a/frontend/src/pages/CoreFeaturesPage.svelte
+++ b/frontend/src/pages/CoreFeaturesPage.svelte
@@ -1,0 +1,270 @@
+<script>
+  import { derived, writable } from "svelte/store";
+
+  let count = 1;
+  let name = "Svelte enthusiast";
+  let slider = 35;
+  const tips = writable([
+    "Props update automatically",
+    "Stores make state global",
+    "Bindings keep DOM and state in sync"
+  ]);
+
+  const tipCount = derived(tips, ($tips) => $tips.length);
+  let newTip = "";
+
+  $: double = count * 2;
+  $: triple = count * 3;
+  $: excitement = Math.round((slider / 100) * 10);
+  $: greeting = name.trim() ? `Hello, ${name.trim()}!` : "Say hi with your name";
+
+  function increment(step = 1) {
+    count += step;
+  }
+
+  function decrement(step = 1) {
+    count = Math.max(0, count - step);
+  }
+
+  function addTip() {
+    const trimmed = newTip.trim();
+    if (!trimmed) return;
+    tips.update((current) => [...current, trimmed]);
+    newTip = "";
+  }
+
+  function removeTip(index) {
+    tips.update((current) => current.filter((_, i) => i !== index));
+  }
+</script>
+
+<div class="features-grid">
+  <section class="card">
+    <header>
+      <h2>Reactive calculations</h2>
+      <p>Update a single value and watch dependent declarations update instantly.</p>
+    </header>
+    <div class="counter">
+      <div class="value">{count}</div>
+      <div class="actions">
+        <button type="button" on:click={() => decrement(1)}>-1</button>
+        <button type="button" on:click={() => increment(1)}>+1</button>
+        <button type="button" on:click={() => increment(5)}>+5</button>
+      </div>
+      <dl>
+        <div>
+          <dt>Double</dt>
+          <dd>{double}</dd>
+        </div>
+        <div>
+          <dt>Triple</dt>
+          <dd>{triple}</dd>
+        </div>
+      </dl>
+    </div>
+  </section>
+
+  <section class="card">
+    <header>
+      <h2>Two-way bindings</h2>
+      <p>Form controls stay in sync with component state through <code>bind:value</code>.</p>
+    </header>
+    <label class="field">
+      Your name
+      <input type="text" bind:value={name} placeholder="Add your name" />
+    </label>
+    <p class="greeting">{greeting}</p>
+
+    <label class="field">
+      Excitement level: {slider}%
+      <input type="range" min="0" max="100" bind:value={slider} />
+    </label>
+    <p class="gauge">🔥 intensity: {"🔥".repeat(Math.max(1, excitement))}</p>
+  </section>
+
+  <section class="card">
+    <header>
+      <h2>Store-driven lists</h2>
+      <p>Shared state lives in a writable store and is derived in real time.</p>
+    </header>
+    <label class="field add-tip">
+      Add a tip
+      <div class="input-row">
+        <input type="text" bind:value={newTip} placeholder="Svelte is..." />
+        <button type="button" on:click={addTip}>Add</button>
+      </div>
+    </label>
+    <p class="hint">{#if $tipCount === 0}No tips yet — share one!{:else}{$tipCount} tips collected{/if}</p>
+
+    <ul class="tips">
+      {#each $tips as tip, index}
+        <li>
+          <span>{tip}</span>
+          <button type="button" class="remove" on:click={() => removeTip(index)}>Remove</button>
+        </li>
+      {/each}
+    </ul>
+  </section>
+</div>
+
+<style>
+  .features-grid {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  @media (min-width: 960px) {
+    .features-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  .card {
+    background: white;
+    padding: clamp(1.5rem, 2.5vw, 2rem);
+    border-radius: 1.25rem;
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 1.25rem;
+  }
+
+  header h2 {
+    margin: 0 0 0.35rem;
+  }
+
+  header p {
+    margin: 0;
+    color: #4a5568;
+    font-size: 0.95rem;
+  }
+
+  .counter {
+    display: grid;
+    gap: 1rem;
+    justify-items: start;
+  }
+
+  .value {
+    font-size: clamp(2.5rem, 4vw, 3rem);
+    font-weight: 700;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.55rem 1.3rem;
+    font-weight: 600;
+    background: linear-gradient(135deg, #4299e1, #667eea);
+    color: white;
+    transition: filter 0.2s ease;
+  }
+
+  button:hover {
+    filter: brightness(1.05);
+  }
+
+  dl {
+    display: grid;
+    gap: 0.5rem;
+    margin: 0;
+  }
+
+  dt {
+    font-weight: 600;
+    color: #4a5568;
+  }
+
+  dd {
+    margin: 0;
+    font-size: 1.35rem;
+    font-weight: 700;
+  }
+
+  .field {
+    display: grid;
+    gap: 0.45rem;
+    font-weight: 600;
+  }
+
+  input[type="text"],
+  input[type="range"] {
+    border: 1px solid #cbd5e0;
+    border-radius: 0.85rem;
+    padding: 0.6rem 0.85rem;
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  input[type="text"]:focus,
+  input[type="range"]:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.25);
+  }
+
+  input[type="range"] {
+    padding: 0;
+  }
+
+  .greeting {
+    margin: 0;
+    font-weight: 600;
+  }
+
+  .gauge {
+    margin: 0;
+    color: #d97706;
+    font-weight: 700;
+  }
+
+  .add-tip .input-row {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  .add-tip input[type="text"] {
+    flex: 1;
+  }
+
+  .hint {
+    margin: 0;
+    color: #4a5568;
+  }
+
+  .tips {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .tips li {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.9rem;
+    padding: 0.75rem 1rem;
+  }
+
+  .tips span {
+    font-weight: 600;
+  }
+
+  .remove {
+    background: #f56565;
+  }
+
+  @media (max-width: 720px) {
+    .features-grid {
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+  }
+</style>

--- a/frontend/src/pages/CrudPage.svelte
+++ b/frontend/src/pages/CrudPage.svelte
@@ -1,0 +1,370 @@
+<script>
+  import { onDestroy } from "svelte";
+  import { get } from "svelte/store";
+  import { createItem, deleteItem, getItems, updateItem } from "../lib/api";
+  import { token, currentUser } from "../stores/auth";
+
+  let items = [];
+  let total = 0;
+  let listLoading = false;
+  let formLoading = false;
+  let errorMessage = "";
+  let successMessage = "";
+  let itemForm = { id: null, title: "", description: "" };
+
+  function resetFeedback() {
+    errorMessage = "";
+    successMessage = "";
+  }
+
+  async function loadItems() {
+    if (!get(token)) {
+      items = [];
+      total = 0;
+      return;
+    }
+    listLoading = true;
+    resetFeedback();
+    try {
+      const response = await getItems();
+      items = response.items;
+      total = response.total;
+    } catch (error) {
+      errorMessage = error.response?.data?.detail ?? "Could not load items";
+    } finally {
+      listLoading = false;
+    }
+  }
+
+  function startCreate() {
+    itemForm = { id: null, title: "", description: "" };
+  }
+
+  function startEdit(item) {
+    itemForm = {
+      id: item.id,
+      title: item.title,
+      description: item.description ?? ""
+    };
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    if (!itemForm.title.trim()) {
+      return;
+    }
+    formLoading = true;
+    resetFeedback();
+    try {
+      if (itemForm.id) {
+        await updateItem(itemForm.id, {
+          title: itemForm.title,
+          description: itemForm.description
+        });
+        successMessage = "Item updated";
+      } else {
+        await createItem({
+          title: itemForm.title,
+          description: itemForm.description
+        });
+        successMessage = "Item created";
+      }
+      startCreate();
+      await loadItems();
+    } catch (error) {
+      errorMessage = error.response?.data?.detail ?? "Could not save item";
+    } finally {
+      formLoading = false;
+    }
+  }
+
+  async function handleDelete(id) {
+    formLoading = true;
+    resetFeedback();
+    try {
+      await deleteItem(id);
+      successMessage = "Item deleted";
+      if (itemForm.id === id) {
+        startCreate();
+      }
+      await loadItems();
+    } catch (error) {
+      errorMessage = error.response?.data?.detail ?? "Could not delete item";
+    } finally {
+      formLoading = false;
+    }
+  }
+
+  const unsubscribe = token.subscribe((value) => {
+    if (!value) {
+      items = [];
+      total = 0;
+      startCreate();
+    } else {
+      loadItems();
+    }
+  });
+
+  onDestroy(unsubscribe);
+
+  $: isEditing = Boolean(itemForm.id);
+</script>
+
+{#if !$currentUser}
+  <div class="card empty-state">
+    <h2>Sign in to manage items</h2>
+    <p>Once authenticated you can create, edit, and delete notes persisted in SQLite.</p>
+  </div>
+{:else}
+  <div class="crud-layout">
+    <section class="card form-card">
+      <header>
+        <div>
+          <h2>{isEditing ? "Update item" : "Create item"}</h2>
+          <p>Fields are fully two-way bound to component state.</p>
+        </div>
+        {#if isEditing}
+          <button type="button" class="secondary" on:click={startCreate} disabled={formLoading}>
+            Cancel edit
+          </button>
+        {/if}
+      </header>
+
+      <form on:submit={handleSubmit}>
+        <label>
+          Title
+          <input type="text" bind:value={itemForm.title} placeholder="What are you working on?" required />
+        </label>
+        <label>
+          Description
+          <textarea rows="4" bind:value={itemForm.description} placeholder="Add a few more details"></textarea>
+        </label>
+        <div class="actions">
+          <button type="submit" disabled={formLoading}>{isEditing ? "Save changes" : "Add item"}</button>
+          <button type="button" class="secondary" on:click={loadItems} disabled={formLoading || listLoading}>
+            Refresh
+          </button>
+        </div>
+      </form>
+    </section>
+
+    <section class="card list-card">
+      <header>
+        <div>
+          <h2>Your items</h2>
+          <p>{listLoading ? "Fetching items…" : `${total} total records`}</p>
+        </div>
+        <button type="button" class="secondary" on:click={loadItems} disabled={listLoading}>
+          Reload
+        </button>
+      </header>
+
+      {#if items.length === 0}
+        <p class="empty">No items yet. Create your first one!</p>
+      {:else}
+        <ul>
+          {#each items as item}
+            <li>
+              <div class="item-copy">
+                <h3>{item.title}</h3>
+                {#if item.description}
+                  <p>{item.description}</p>
+                {/if}
+              </div>
+              <div class="item-actions">
+                <button type="button" class="secondary" on:click={() => startEdit(item)} disabled={formLoading}>
+                  Edit
+                </button>
+                <button type="button" class="danger" on:click={() => handleDelete(item.id)} disabled={formLoading}>
+                  Delete
+                </button>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+  </div>
+{/if}
+
+{#if errorMessage}
+  <div class="feedback error">{errorMessage}</div>
+{/if}
+{#if successMessage}
+  <div class="feedback success">{successMessage}</div>
+{/if}
+
+<style>
+  .card {
+    background: white;
+    padding: clamp(1.5rem, 2.5vw, 2rem);
+    border-radius: 1.25rem;
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  }
+
+  .empty-state {
+    text-align: center;
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .crud-layout {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  @media (min-width: 960px) {
+    .crud-layout {
+      grid-template-columns: 420px 1fr;
+      align-items: start;
+    }
+  }
+
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+  }
+
+  header h2 {
+    margin: 0 0 0.35rem;
+  }
+
+  header p {
+    margin: 0;
+    color: #4a5568;
+    font-size: 0.95rem;
+  }
+
+  form {
+    display: grid;
+    gap: 1rem;
+  }
+
+  label {
+    display: grid;
+    gap: 0.45rem;
+    font-weight: 600;
+  }
+
+  input,
+  textarea {
+    border: 1px solid #cbd5e0;
+    border-radius: 0.85rem;
+    padding: 0.7rem 0.85rem;
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  input:focus,
+  textarea:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.25);
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.65rem 1.4rem;
+    font-weight: 600;
+    background: linear-gradient(135deg, #4299e1, #667eea);
+    color: white;
+    transition: filter 0.2s ease;
+  }
+
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  button:not(:disabled):hover {
+    filter: brightness(1.05);
+  }
+
+  .secondary {
+    background: #edf2f7;
+    color: #2d3748;
+  }
+
+  .danger {
+    background: #f56565;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 1rem;
+  }
+
+  li {
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    border: 1px solid #e2e8f0;
+    border-radius: 1rem;
+    padding: 1rem;
+  }
+
+  .item-copy h3 {
+    margin: 0 0 0.35rem;
+  }
+
+  .item-copy p {
+    margin: 0;
+    color: #4a5568;
+  }
+
+  .item-actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .empty {
+    color: #718096;
+  }
+
+  .feedback {
+    margin-top: 1.5rem;
+    padding: 0.85rem 1rem;
+    border-radius: 0.9rem;
+    font-weight: 600;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  }
+
+  .feedback.error {
+    background: #fed7d7;
+    color: #742a2a;
+  }
+
+  .feedback.success {
+    background: #c6f6d5;
+    color: #22543d;
+  }
+
+  @media (max-width: 640px) {
+    li {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .item-actions {
+      justify-content: flex-end;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- refactor the main Svelte app into a navigable shell with authentication-aware page switching
- add standalone pages demonstrating authentication, CRUD interactions, database queries, and core Svelte reactivity
- enhance the items API client to accept query parameters for pagination-driven demos

## Testing
- npm install *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68dd611de57c83289068b06609da7497