### PR TITLE
Fix FastAPI startup on Python 3.13

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,8 @@
+# Ensure runtime patches are applied before importing FastAPI and its
+# dependencies. This prevents issues with Python 3.13 and older Pydantic
+# releases that FastAPI still depends on.
+from . import pycompat  # noqa: F401
+
 from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import OAuth2PasswordRequestForm

--- a/backend/app/pycompat.py
+++ b/backend/app/pycompat.py
@@ -1,0 +1,25 @@
+"""Compatibility helpers for runtime edge cases."""
+from __future__ import annotations
+
+import sys
+from typing import ForwardRef
+
+
+if sys.version_info >= (3, 13):  # pragma: no cover - runtime safeguard
+    # Python 3.13 made ``typing.ForwardRef._evaluate`` require the ``recursive_guard``
+    # keyword argument. Pydantic v1 still calls it positionally which raises
+    # ``TypeError`` during FastAPI's import phase. Patching the method keeps the
+    # older call signature while delegating to the updated implementation.
+    _original_evaluate = ForwardRef._evaluate
+
+    def _patched_evaluate(self, globalns, localns, recursive_guard=None):
+        if recursive_guard is None:
+            recursive_guard = set()
+        return _original_evaluate(
+            self,
+            globalns,
+            localns,
+            recursive_guard=recursive_guard,
+        )
+
+    ForwardRef._evaluate = _patched_evaluate  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- add a Python 3.13 compatibility shim that patches ForwardRef evaluation so pydantic v1 continues working
- ensure the compatibility patch is loaded before importing FastAPI

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68dd6b27efa88328896ffe72edd3a80d