### PR TITLE
Fix frontend reactivity and update backend for Pydantic 2

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -31,7 +31,7 @@ def list_items(db: Session, owner_id: int, skip: int = 0, limit: int = 20) -> Tu
 
 
 def create_item(db: Session, item: schemas.ItemCreate, owner_id: int) -> models.Item:
-    db_item = models.Item(**item.dict(), owner_id=owner_id)
+    db_item = models.Item(**item.model_dump(), owner_id=owner_id)
     db.add(db_item)
     db.commit()
     db.refresh(db_item)
@@ -46,7 +46,7 @@ def update_item(db: Session, item_id: int, item: schemas.ItemUpdate, owner_id: i
     )
     if not db_item:
         return None
-    for key, value in item.dict(exclude_unset=True).items():
+    for key, value in item.model_dump(exclude_unset=True).items():
         setattr(db_item, key, value)
     db.commit()
     db.refresh(db_item)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, ConfigDict
 
 
 class Token(BaseModel):
@@ -24,8 +24,7 @@ class UserRead(UserBase):
     id: int
     is_active: bool
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ItemBase(BaseModel):
@@ -45,8 +44,7 @@ class ItemRead(ItemBase):
     id: int
     owner_id: int
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class PaginatedItems(BaseModel):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.110.0
 uvicorn[standard]==0.27.0
 sqlalchemy==2.0.25
-pydantic[email]==1.10.13
+pydantic[email]==2.6.4
 passlib[bcrypt]==1.7.4
 python-jose[cryptography]==3.3.0

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -42,6 +42,7 @@
   const pageMap = new Map(pages.map((page) => [page.id, page]));
 
   let activePage = pages[0].id;
+  let activeDefinition = pages[0];
   let profileError = "";
   let loadingProfile = false;
 
@@ -82,9 +83,14 @@
     activePage = "crud";
   }
 
-  $: activeDefinition = pageMap.get(activePage) ?? pages[0];
-  $: if (!$token && activeDefinition.requiresAuth) {
-    activePage = "auth";
+  $: {
+    const definition = pageMap.get(activePage) ?? pages[0];
+    if (!$token && definition.requiresAuth) {
+      activePage = "auth";
+      activeDefinition = pageMap.get("auth") ?? pages[0];
+    } else {
+      activeDefinition = definition;
+    }
   }
 </script>
 


### PR DESCRIPTION
## Summary
- resolve the reactive cycle in the app shell by deriving the active page definition in a single block
- upgrade the backend to Pydantic 2.6 and update schemas and CRUD helpers for the new API

## Testing
- pip install -r requirements.txt *(fails: proxy error 403 when reaching package index)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6c30ce0083288f14d4813c54db30