### PR TITLE
Fix SQLAlchemy Python 3.13 assertion error

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.110.0
 uvicorn[standard]==0.27.0
-sqlalchemy==2.0.25
+sqlalchemy==2.0.36
 pydantic[email]==2.6.4
 passlib[bcrypt]==1.7.4
 python-jose[cryptography]==3.3.0


### PR DESCRIPTION
## Summary
- bump SQLAlchemy requirement to 2.0.36 to restore compatibility with Python 3.13

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de233b6c54832882c9180d18c31639