### PR TITLE
Fix SQLAlchemy typing assertion under Python 3.13

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.110.0
 uvicorn[standard]==0.27.0
-sqlalchemy==2.0.36
+sqlalchemy==2.0.39
 pydantic[email]==2.6.4
 passlib[bcrypt]==1.7.4
 python-jose[cryptography]==3.3.0


### PR DESCRIPTION
## Summary
- bump SQLAlchemy to 2.0.39 so it remains compatible with Python 3.13

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de2410853c8328aeffd20e4f483ad2