### PR TITLE
Fix SQLAlchemy requirement for Python 3.13 compatibility

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.110.0
 uvicorn[standard]==0.27.0
-sqlalchemy==2.0.39
+sqlalchemy>=2.0.41,<2.1
 pydantic[email]==2.6.4
 passlib[bcrypt]==1.7.4
 python-jose[cryptography]==3.3.0


### PR DESCRIPTION
## Summary
- raise the SQLAlchemy requirement to a Python 3.13-compatible release range

## Testing
- pip install -r backend/requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68de256613e08328b2943365b105d2f0