### PR TITLE
Switch project to Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ The backend exposes:
 
 ### Install & run
 
+> **Python version:** The backend is tested with Python 3.11. Ensure your virtual
+> environment uses this interpreter to avoid compatibility issues.
+
 ```bash
 cd backend
-python -m venv .venv
+python3.11 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 uvicorn app.main:app --reload

--- a/backend/justfile
+++ b/backend/justfile
@@ -2,7 +2,7 @@ default:
 	cat justfile
 
 setup:
-	python3.12 -m venv .venv
+	python3.11 -m venv .venv
 	python -m pip install --upgrade pip
 	pip install uv
 


### PR DESCRIPTION
## Summary
- update the backend setup instructions to target Python 3.11
- switch the backend Just task to create virtual environments with python3.11

## Testing
- python3 -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68de2961b17c83288e4351605b176361