### PR TITLE
Limit password length to bcrypt maximum

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel, EmailStr, ConfigDict
+from pydantic import BaseModel, ConfigDict, EmailStr, constr
 
 
 class Token(BaseModel):
@@ -17,7 +17,8 @@ class UserBase(BaseModel):
 
 
 class UserCreate(UserBase):
-    password: str
+    # bcrypt rejects passwords longer than 72 bytes, so enforce the limit early
+    password: constr(max_length=72)
 
 
 class UserRead(UserBase):


### PR DESCRIPTION
## Summary
- enforce a 72-character maximum on user passwords in the API schema
- document the bcrypt limitation to avoid runtime hashing failures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de2e0bc2d883289ca8bcae09314cf5