### PR TITLE
Fix vite preprocess import path for SvelteKit 2

### DIFF
--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,5 +1,5 @@
 import adapter from "@sveltejs/adapter-auto";
-import { vitePreprocess } from "@sveltejs/kit/vite";
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 const config = {
   preprocess: vitePreprocess(),


### PR DESCRIPTION
## Summary
- update the `vitePreprocess` import to use `@sveltejs/vite-plugin-svelte`

## Testing
- npm install *(fails: registry returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de44790fb88328b60913edb74ccd46