### PR TITLE
Fix SvelteKit adapter configuration

### DIFF
--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -4,7 +4,7 @@ import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 const config = {
   preprocess: vitePreprocess(),
   kit: {
-    adapter,
+    adapter: adapter(),
     alias: {
       $stores: "src/lib/stores"
     }


### PR DESCRIPTION
## Summary
- call the SvelteKit adapter factory in the config so the adapter exposes an adapt method

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68de45072030832890c58f159fc7e994